### PR TITLE
fix: owner can set fee to be greater than 100%

### DIFF
--- a/src/Cally.sol
+++ b/src/Cally.sol
@@ -115,8 +115,11 @@ contract Cally is CallyNft, ReentrancyGuard, Ownable, ERC721TokenReceiver {
     **********************/
 
     /// @notice Sets the fee that is applied on exercise
-    /// @param feeRate_ The new fee rate: fee = 1% = (1 / 100) * 1e18
+    /// @param feeRate_ The new fee rate, ex: feeRate = 1% = 1e18 * (1 / 100)
+    ///                 1e18 is equal to 100% feeRate.
     function setFee(uint256 feeRate_) external onlyOwner {
+        require(feeRate_ <= (1e18 * 30) / 100, "Fee cannot be larger than 30%");
+
         feeRate = feeRate_;
     }
 

--- a/test/units/Admin.t.sol
+++ b/test/units/Admin.t.sol
@@ -18,6 +18,15 @@ contract TestAdmin is Test, Fixture {
         assertEq(feeRate, newFeeRate, "Should have set fee rate");
     }
 
+    function testItCannotSetFeeHigherThanThreshold() public {
+        // arrange
+        uint256 newFeeRate = (1e18 * 31) / 100;
+
+        // act
+        vm.expectRevert("Fee cannot be larger than 30%");
+        c.setFee(newFeeRate);
+    }
+
     function testItCannotLetNonAdminSetFee() public {
         // arrange
         vm.prank(babe);


### PR DESCRIPTION
fixes: https://github.com/code-423n4/2022-05-cally-findings/issues/48

Add a cap on the feeRate to be 30% at most so that there is no potential overflow when calculating fees.