### PR TITLE
fix: excess ether transferred to buyOption causes unnecessary loss to the buyer

### DIFF
--- a/src/Cally.sol
+++ b/src/Cally.sol
@@ -261,7 +261,7 @@ contract Cally is CallyNft, ReentrancyGuard, Ownable, ERC721TokenReceiver {
 
         // check enough eth was sent to cover premium
         uint256 premium = getPremium(vaultId);
-        require(msg.value >= premium, "Incorrect ETH amount sent");
+        require(msg.value == premium, "Incorrect ETH amount sent");
 
         // check option associated with the vault has expired
         uint32 auctionStartTimestamp = vault.currentExpiration;

--- a/test/units/BuyOption.t.sol
+++ b/test/units/BuyOption.t.sol
@@ -203,6 +203,12 @@ contract TestBuyOption is Fixture {
         c.buyOption{value: premium}(2);
     }
 
+    function testItCannotBuyOptionIfValueIsGreaterThanPremium() {
+        // act
+        vm.expectRevert("Incorrect ETH amount sent");
+        c.buyOption{value: premium}(vaultId);
+    }
+
     function testItBuysOption(uint256 vaultId_) public {
         // arrange
         vm.assume(vaultId_ % 2 != 0);


### PR DESCRIPTION
Fixes: https://github.com/code-423n4/2022-05-cally-findings/issues/84

makes the msg.value check exact in `buyOption`